### PR TITLE
Make it possible to use without module bundler

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -1,7 +1,7 @@
 import { Subscribable, Observer, TeardownLogic } from 'rxjs';
 import { IpcRenderer, ipcRenderer, Event } from 'electron';
-import * as uuidv4 from 'uuid/v4';
-import * as Errio from 'errio';
+import uuidv4 from 'uuid/v4';
+import Errio from 'errio';
 import { IpcProxyError } from './utils';
 import {
     Request, RequestType,

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,12 +1,12 @@
 import { Subscribable, Observer, TeardownLogic } from 'rxjs';
 import { IpcRenderer, ipcRenderer, Event } from 'electron';
-import uuidv4 from 'uuid/v4';
-import Errio from 'errio';
+import * as uuidv4 from 'uuid/v4';
+import * as Errio from 'errio';
 import { IpcProxyError } from './utils';
-import { 
-    Request, RequestType, 
-    Response, ResponseType, 
-    ProxyDescriptor, ProxyPropertyType 
+import {
+    Request, RequestType,
+    Response, ResponseType,
+    ProxyDescriptor, ProxyPropertyType
 } from './common';
 
 export interface ObservableConstructor {
@@ -44,7 +44,7 @@ function getProperty(propertyType: ProxyPropertyType, propKey: string, channel: 
         case ProxyPropertyType.Function:
             return (...args: any[]) => makeRequest({ type: RequestType.Apply, propKey, args }, channel, transport);
         case ProxyPropertyType.Function$:
-            return (...args: any[]) => makeObservable({ type: RequestType.ApplySubscribe, propKey, args }, channel, ObservableCtor, transport);            
+            return (...args: any[]) => makeObservable({ type: RequestType.ApplySubscribe, propKey, args }, channel, ObservableCtor, transport);
         default:
             throw new IpcProxyError(`Unrecognised ProxyPropertyType [${propertyType}]`);
     }
@@ -93,7 +93,7 @@ function makeObservable(request: Request, channel: string, ObservableCtor: Obser
 
         makeRequest(subscriptionRequest, channel, transport)
             .catch((err: Error) => {
-                console.log('Error subscribing to remote observable', err);                    
+                console.log('Error subscribing to remote observable', err);
                 obs.error(err);
             });
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,8 +1,8 @@
 import { Observable, Subscription } from 'rxjs';
 import { ipcMain, IpcMain, Event, WebContents } from 'electron';
-import Errio from 'errio';
+import * as Errio from 'errio';
 import { IpcProxyError, isFunction, isObservable } from './utils';
-import { 
+import {
     Request, RequestType, ResponseType,
     GetRequest, ApplyRequest, SubscribeRequest, UnsubscribeRequest,
     ProxyDescriptor, ProxyPropertyType, ApplySubscribeRequest
@@ -12,11 +12,11 @@ const registrations: { [channel: string]: ProxyServerHandler | null } = {};
 
 export function registerProxy<T>(target: T, descriptor: ProxyDescriptor, transport: IpcMain = ipcMain): VoidFunction {
     const { channel } = descriptor;
-    
+
     if (registrations[channel]) {
         throw new IpcProxyError(`Proxy object has already been registered on channel ${channel}`);
     }
-    
+
     const server = new ProxyServerHandler(target);
     registrations[channel] = server;
 
@@ -24,7 +24,7 @@ export function registerProxy<T>(target: T, descriptor: ProxyDescriptor, transpo
         let { sender } = event;
         sender.once('destroyed', () => { sender = null });
 
-        server.handleRequest(request, sender)        
+        server.handleRequest(request, sender)
             .then(result => sender && sender.send(correlationId, { type: ResponseType.Result, result }))
             .catch(error => sender && sender.send(correlationId, { type: ResponseType.Error, error: Errio.stringify(error) }));
     });
@@ -48,7 +48,7 @@ class ProxyServerHandler {
     constructor(private target: any) {}
 
     private subscriptions: { [subscriptionId: string]: Subscription } = {};
-    
+
     public async handleRequest(request: Request, sender: WebContents): Promise<any> {
         switch (request.type) {
             case RequestType.Get:
@@ -105,7 +105,7 @@ class ProxyServerHandler {
             throw new IpcProxyError(`Remote property [${propKey}] is not a function`)
         }
 
-        const obs = func.apply(this.target, args);        
+        const obs = func.apply(this.target, args);
 
         if (!isObservable(obs)) {
             throw new IpcProxyError(`Remote function [${propKey}] did not return an observable`);
@@ -113,7 +113,7 @@ class ProxyServerHandler {
 
         this.doSubscribe(obs, subscriptionId, sender);
     }
-    
+
     private doSubscribe(obs: Observable<any>, subscriptionId: string, sender: WebContents) {
         if (this.subscriptions[subscriptionId]) {
             throw new IpcProxyError(`A subscription with Id [${subscriptionId}] already exists`);
@@ -126,7 +126,7 @@ class ProxyServerHandler {
         );
 
         /* If the sender does not clean up after itself then we need to do it */
-        sender.once('destroyed', () => this.doUnsubscribe(subscriptionId));        
+        sender.once('destroyed', () => this.doUnsubscribe(subscriptionId));
     }
 
     private handleUnsubscribe(request: UnsubscribeRequest) {
@@ -142,7 +142,7 @@ class ProxyServerHandler {
     private doUnsubscribe(subscriptionId: string) {
         const subscription = this.subscriptions[subscriptionId];
 
-        if (subscription) {        
+        if (subscription) {
             subscription.unsubscribe();
             delete this.subscriptions[subscriptionId];
         }

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,6 +1,6 @@
 import { Observable, Subscription } from 'rxjs';
 import { ipcMain, IpcMain, Event, WebContents } from 'electron';
-import * as Errio from 'errio';
+import Errio from 'errio';
 import { IpcProxyError, isFunction, isObservable } from './utils';
 import {
     Request, RequestType, ResponseType,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,5 @@
 import { Observable } from 'rxjs';
-import Errio from 'errio';
+import * as Errio from 'errio';
 
 /* Custom Error */
 export class IpcProxyError extends Error {
@@ -18,4 +18,3 @@ export function isFunction(value: any): value is Function {
 export function isObservable<T>(value: any): value is Observable<T> {
     return value && typeof value.subscribe === 'function'
 }
-

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,5 @@
 import { Observable } from 'rxjs';
-import * as Errio from 'errio';
+import Errio from 'errio';
 
 /* Custom Error */
 export class IpcProxyError extends Error {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
-    "target": "es2016",
-    "module": "esnext",
+    "target": "es2015",
+    "module": "commonjs",
     "moduleResolution": "node",
     "allowSyntheticDefaultImports": true,
     "declaration": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,7 @@
     "sourceMap": true,
     "noEmitHelpers": true,
     "importHelpers": true,
+    "esModuleInterop": true,
     "strict": true,
     "strictFunctionTypes": false,
     "strictNullChecks": false,


### PR DESCRIPTION
This PR changes the ES target to es2015 (which safely supported by all recent node versions)
and the module system to nodes CommonJS, which makes it possible to use the Library without a module bundler like rollup, webpack or a transpiler.

All tests are still passing.